### PR TITLE
add conda build function

### DIFF
--- a/bld.bat
+++ b/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
+if errorlevel 1 exit 1

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON $SRC_DIR/setup.py install --single-version-externally-managed --record=record.txt

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,36 @@
+package:
+    name: pycwr
+    version: 0.2
+
+build:
+    skip: True # [py<35]
+
+source:
+    git_url: https://github.com/YvZheng/pycwr.git
+
+requirements:
+    build:
+       - python
+
+    host:
+       - python
+       - setuptools
+
+    run:
+        - 'python >=3.6*'
+        - 'numpy <=1.15.0'
+        - 'scipy >=1.1.0'
+        - 'matplotlib >=2.2.3'
+        - 'netcdf4 >=1.5.3'
+        - 'cartopy >=0.17*'
+        - 'pandas >=0.23.4'
+        - 'easydict >=1.9'
+        - 'pyproj >=1.9.6'
+        - 'xarray >=0.13*'
+        - 'pyqt >=5.10*'
+
+about:
+    home: https://github.com/YvZheng/pycwr
+    description: 
+    license: MIT
+    license_file: LICENSE.txt


### PR DESCRIPTION
add some scripts (build.sh on linux and osx, bld.bat on windows) and file (meta.yaml) for using conda build to create distributions on all platforms.  