### PR TITLE
fix: avoid error by adding additional condition

### DIFF
--- a/pycwr/draw/colormap/cm.py
+++ b/pycwr/draw/colormap/cm.py
@@ -110,7 +110,7 @@ def _reverse_cmap_spec(spec):
     type specs."""
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", FutureWarning)
-        if 'red' in spec:
+        if isinstance(spec, dict) and 'red' in spec:
             return revcmap(spec)
         else:
             revspec = list(reversed(spec))
@@ -126,7 +126,7 @@ def _generate_cmap(name, lutsize):
     spec = datad[name]
 
     # Generate the colormap object.
-    if 'red' in spec:
+    if isinstance(spec, dict) and 'red' in spec:
         return colors.LinearSegmentedColormap(name, spec, lutsize)
     else:
         return colors.LinearSegmentedColormap.from_list(name, spec, lutsize)

--- a/pycwr/draw/colormap/cm_colorblind.py
+++ b/pycwr/draw/colormap/cm_colorblind.py
@@ -34,7 +34,7 @@ def _generate_cmap(name, lutsize):
     # Generate the colormap object.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", FutureWarning)
-        if 'red' in spec:
+        if isinstance(spec, dict) and 'red' in spec:
             return colors.LinearSegmentedColormap(name, spec, lutsize)
         else:
             return colors.LinearSegmentedColormap.from_list(name, spec, lutsize)


### PR DESCRIPTION
When using pycwr, an error is throw:
```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
This is because some spec is a list of narray, which can not use `in` statement directly.
Since field `red` is only use in `dict` type of cmap spec, I make some minor fix on `if` statement condition and it works fine in my local machine.
I think it can be merged, hoping for your review.